### PR TITLE
adds flexibility when spint id isn't known, and reorders console.logs

### DIFF
--- a/src/get-issue-report.ts
+++ b/src/get-issue-report.ts
@@ -1,17 +1,34 @@
 import * as axios from "axios";
-const RAPID_VIEW = process.env.RAPID_VIEW;
-const SPRINT_ID = process.env.SPRINT_ID;
-export async function getIssueReport() {
-    return await axios.default.get(
-        `https://gathertech.atlassian.net/rest/greenhopper/latest/rapid/charts/sprintreport?rapidViewId=${RAPID_VIEW}&sprintId=${SPRINT_ID}`,
-        {
-            headers: {
-                "Content-Type": "application/json"
-            },
-            auth: {
-                username: process.env.JIRA_USERNAME,
-                password: process.env.JIRA_PASSWORD
-            }
-        }
-    );
+
+const credentials = {
+    headers: {
+        "Content-Type": "application/json"
+    },
+    auth: {
+        username: process.env.JIRA_USERNAME,
+        password: process.env.JIRA_PASSWORD
+    }
 }
+
+export async function getSprintId(boardId) {
+    const { data: { values: sprints } } = await axios.default.get(
+        `https://gathertech.atlassian.net/rest/agile/1.0/board/${boardId}/sprint`, credentials
+    );
+    const sprint = sprints.find(allSprints => allSprints.state === 'active');
+    return sprint.id;
+}
+
+export async function getBoardId(boardName) {
+    const { data: { values: boards } } = await axios.default.get(
+        `https://gathertech.atlassian.net/rest/agile/1.0/board`, credentials
+    );
+    const board = boards.find(allBoards => allBoards.name === boardName);
+    return board.id;
+};
+
+export async function getIssueReport(boardId, sprintId) {
+    return await axios.default.get(
+        `https://gathertech.atlassian.net/rest/greenhopper/latest/rapid/charts/sprintreport?rapidViewId=${boardId}&sprintId=${sprintId}`,
+        credentials
+    );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ const [, , cliBoardName, cliSprintId] = process.argv;
         return !issue.done;
     });
 
+    const originalIssuesEstimateCountNotDone = sumPointsFromIssues(originalIssuesNotDone);
+
     const pointsFromOriginalIssuesNotDone = sumPointsFromIssues(originalIssuesNotDone);
     const pointsFromOriginalIssuesAccomplished =
         pointsFromOriginalIssuesEstimate - pointsFromOriginalIssuesNotDone;
@@ -82,11 +84,21 @@ const [, , cliBoardName, cliSprintId] = process.argv;
         sumPointsFromIssues(doneAddedIssues)
     );
     console.log("points punted from original estimate: ", pointsPuntedFromOriginalIssues);
+    console.log("points not completed from original estimate:", originalIssuesEstimateCountNotDone);
     console.log(
         "issues not done status: ",
         originalIssuesNotDone.map(
             (issue) =>
                 `${issue.key} ${issue.summary} (${(issue.section === "not completed" ? issue.status.name : issue.section)})`
+        )
+    );
+    console.log(
+        "issues added during sprint: ",
+        issuesNotOriginallyInSprint.map(
+            (issue) =>
+                `${issue.key} ${issue.summary} ` +
+                `(${(issue.section === "not completed" ? issue.status.name : issue.section)}) ` +
+                `(${issue.estimateStatistic ? issue.estimateStatistic.statFieldValue.value + ' points' : 'not pointed'})`
         )
     );
 })();


### PR DESCRIPTION
Adds the ability to generate sprint report without knowing the sprint ID, or by passing in the sprint ID. 

Optionally, pass in the name of the Jira board to generate the sprint report, example:
`yarn start "BMF"` - to generate report for "BMF" Jira Board with the currently active sprint
or 
`yarn start` - to generate report for default "APP board" Jira board.

Optionally, add `alias sprintReport='yarn --cwd ~/{releative_path}/jira-tools start'` to .zshrc or .bash_profile to make generating the report even easier :), example:
`sprintReport "BMF"` - to generate report for "BMF" Jira Board with the currently active sprint
or 
`sprintReport "BMF" 121` - to generate report for "BMF" Jira Board with the sprint ID 121.