### PR TITLE
use graphql api to get rockets

### DIFF
--- a/src/get-reaction-rockets.ts
+++ b/src/get-reaction-rockets.ts
@@ -1,11 +1,90 @@
 import axios from "axios";
 import { credentials } from "./credentials";
 
-async function getComments(repository, prNumber) {
-    const { data } = await axios.get(
-        `https://api.github.com/repos/squareup/${repository}/pulls/${prNumber}/comments`, credentials
+export async function getPrRocketComments(repository, prNumber): Promise<Array<RocketComments>> {
+    const graphqlQuery = `
+    query {
+        repository(name: "${repository}" owner: "squareup") {
+          pullRequest(number: ${prNumber}) {
+            reviews(first: 100) {
+              edges {
+                node {
+                  id
+                  body
+                  url
+                  author {
+                    login
+                  }
+                  reactions(first:10) {
+                    edges {
+                      node {
+                        id
+                        content
+                      }
+                    }
+                  }
+                  comments(first:100) {
+                    edges {
+                      node {
+                        id
+                        body
+                        author {
+                          login
+                        }
+                        reactions(first:10) {
+                          edges {
+                            node {
+                              id
+                              content
+                            }
+                          }
+                        }
+                        url
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+    const { data: response } = await axios.post(
+        `https://api.github.com/graphql`, {
+            query: graphqlQuery
+        }, credentials
     );
-    return data;
+    const reviewData = response.data.repository.pullRequest.reviews.edges;
+    let rocketComments: Array<RocketComments> = [];
+    for (const review of reviewData) {
+        const topLevelRockets = getRockets(review.node.reactions.edges);
+        if (topLevelRockets > 0) {
+            rocketComments.push({
+                url: review.node.url,
+                body: review.node.body,
+                rockets: topLevelRockets,
+                ghUsername: review.node.author.login
+            })
+        }
+        const comments = review.node.comments.edges;
+        for (const comment of comments) {
+            const commentRockets = getRockets(comment.node.reactions.edges)
+            if (commentRockets > 0) {
+                rocketComments.push({
+                    url: comment.node.url,
+                    body: comment.node.body,
+                    rockets: commentRockets,
+                    ghUsername: comment.node.author.login
+                })
+            }
+        }
+    }
+    return rocketComments;
+}
+
+function getRockets(reactions: Array<any>): number {
+    return reactions.filter(reaction => reaction.node.content === "ROCKET").length;
 }
 
 export interface RocketComments {
@@ -13,23 +92,4 @@ export interface RocketComments {
     url: String;
     rockets: number;
     ghUsername: String;
-}
-
-export async function getPrRocketComments(repository: string, prNumber: string): Promise<Array<RocketComments>> {
-    const commentsRaw = await getComments(repository, prNumber);
-    const rocketComments: Array<RocketComments> = [];
-    for (const comment of commentsRaw) {
-        const rockets = comment["reactions"]["rocket"];
-        if (rockets == 0) {
-            continue;
-        }
-        rocketComments.push({
-            body: comment["body"],
-            url: comment["_links"]["html"]["href"],
-            rockets,
-            ghUsername: comment["user"]["login"],
-        });
-
-    }
-    return rocketComments;
 }


### PR DESCRIPTION
there are a bunch of ways of retrieving rocket comments via the REST API which required a bunch of extra requests and wasn't completely available.  the graphql api is more complete and requires fewer round-trips  